### PR TITLE
Adding random fact domain layer

### DIFF
--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -17,7 +17,7 @@ const val RX_BINDING_VERSION = "2.1.1"
 const val JUNIT_VERSION = "4.12"
 const val TEST_RUNNER_VERSION = "1.0.2"
 const val ESPRESSO_VERSION = "3.0.2"
-const val MOCKITO_VERSION = "1.9.5"
+const val MOCKITO_VERSION = "0.9.0"
 const val TEST_RULES_VERSION = "1.0.2"
 const val RETROFIT_VERSION = "2.4.0"
 const val LOGGING_VERSION = "3.10.0"
@@ -57,5 +57,5 @@ object AndroidTest {
 
 object UnitTest {
     val jUnit = "junit:junit:$JUNIT_VERSION"
-    val mockito = "org.mockito:mockito-all:$MOCKITO_VERSION"
+    val mockito = "com.nhaarman:mockito-kotlin:$MOCKITO_VERSION"
 }

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/GetRandomicFact.java
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/GetRandomicFact.java
@@ -1,4 +1,0 @@
-package br.stone.mobiletraining.samilasantos.domain;
-
-public class GetRandomicFact {
-}

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/Fact.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/Fact.kt
@@ -1,0 +1,7 @@
+package br.stone.mobiletraining.samilasantos.domain.common
+
+data class Fact(
+    val id: String,
+    val description: String,
+    val url: String
+)

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/IntegrationErrors.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/IntegrationErrors.kt
@@ -1,0 +1,7 @@
+package br.stone.mobiletraining.samilasantos.domain.common
+
+sealed class IntegrationErrors : Throwable() {
+    object FactNotFound : IntegrationErrors()
+    object UnavailableProvider : IntegrationErrors()
+    object UnexpectedData : IntegrationErrors()
+}

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/IntegrationErrors.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/IntegrationErrors.kt
@@ -1,7 +1,0 @@
-package br.stone.mobiletraining.samilasantos.domain.common
-
-sealed class IntegrationErrors : Throwable() {
-    object FactNotFound : IntegrationErrors()
-    object UnavailableProvider : IntegrationErrors()
-    object UnexpectedData : IntegrationErrors()
-}

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/IntegrationExceptions.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/IntegrationExceptions.kt
@@ -1,0 +1,6 @@
+package br.stone.mobiletraining.samilasantos.domain.common
+
+sealed class IntegrationExceptions : Throwable() {
+    object UnavailableProvider : IntegrationExceptions()
+    object UnexpectedData : IntegrationExceptions()
+}

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/NetworkIssues.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/common/NetworkIssues.kt
@@ -1,0 +1,6 @@
+package br.stone.mobiletraining.samilasantos.domain.common
+
+sealed class NetworkIssues : Throwable() {
+    object NoNetwork : NetworkIssues()
+    object Timeout : NetworkIssues()
+}

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactRepository.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactRepository.kt
@@ -1,8 +1,8 @@
 package br.stone.mobiletraining.samilasantos.domain.randomFact
 
 import br.stone.mobiletraining.samilasantos.domain.common.Fact
-import io.reactivex.Observable
+import io.reactivex.Single
 
 interface RandomFactRepository {
-    fun getFact(): Observable<Fact>
+    fun getFact(): Single<Fact>
 }

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactRepository.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactRepository.kt
@@ -1,0 +1,8 @@
+package br.stone.mobiletraining.samilasantos.domain.randomFact
+
+import br.stone.mobiletraining.samilasantos.domain.common.Fact
+import io.reactivex.Observable
+
+interface RandomFactRepository {
+    fun getFact(): Observable<Fact>
+}

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactResult.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactResult.kt
@@ -1,0 +1,8 @@
+package br.stone.mobiletraining.samilasantos.domain.randomFact
+
+import br.stone.mobiletraining.samilasantos.domain.common.Fact
+
+sealed class RandomFactResult {
+    data class Success(val fact: Fact) : RandomFactResult()
+    data class Error(val error: Throwable) : RandomFactResult()
+}

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/uc/GetRandomFact.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/uc/GetRandomFact.kt
@@ -1,0 +1,11 @@
+package br.stone.mobiletraining.samilasantos.domain.randomFact.uc
+
+import br.stone.mobiletraining.samilasantos.domain.randomFact.RandomFactRepository
+import br.stone.mobiletraining.samilasantos.domain.randomFact.RandomFactResult
+import io.reactivex.Observable
+
+class GetRandomFact(private val repository: RandomFactRepository) {
+    fun execute(): Observable<RandomFactResult> = repository.getFact()
+        .map { RandomFactResult.Success(it) as RandomFactResult }
+        .onErrorReturn { RandomFactResult.Error(it) }
+}

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/uc/GetRandomFact.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/uc/GetRandomFact.kt
@@ -2,10 +2,10 @@ package br.stone.mobiletraining.samilasantos.domain.randomFact.uc
 
 import br.stone.mobiletraining.samilasantos.domain.randomFact.RandomFactRepository
 import br.stone.mobiletraining.samilasantos.domain.randomFact.RandomFactResult
-import io.reactivex.Observable
+import io.reactivex.Single
 
 class GetRandomFact(private val repository: RandomFactRepository) {
-    fun execute(): Observable<RandomFactResult> = repository.getFact()
+    fun execute(): Single<RandomFactResult> = repository.getFact()
         .map { RandomFactResult.Success(it) as RandomFactResult }
         .onErrorReturn { RandomFactResult.Error(it) }
 }

--- a/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/uc/RandomFactExceptions.kt
+++ b/domain/src/main/java/br/stone/mobiletraining/samilasantos/domain/randomFact/uc/RandomFactExceptions.kt
@@ -1,0 +1,5 @@
+package br.stone.mobiletraining.samilasantos.domain.randomFact.uc
+
+sealed class RandomFactExceptions : Throwable() {
+    object FactNotFound : RandomFactExceptions()
+}

--- a/domain/src/test/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactMother.kt
+++ b/domain/src/test/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactMother.kt
@@ -1,0 +1,52 @@
+package br.stone.mobiletraining.samilasantos.domain.randomFact
+
+import br.stone.mobiletraining.samilasantos.domain.common.Fact
+import br.stone.mobiletraining.samilasantos.domain.common.IntegrationErrors
+import br.stone.mobiletraining.samilasantos.domain.common.NetworkIssues
+import io.reactivex.Observable
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+object RandomFactMother {
+    val repository: RandomFactRepository = mock(RandomFactRepository::class.java)
+
+    fun withASuccessScenario(func: () -> Unit) {
+        `when`(repository.getFact())
+            .thenReturn(
+                Observable.just(Fact(id = "AFEG7878DD",
+                    description = "Chuck Norris is Extreme Go Horse Father",
+                    url = "")
+                ))
+        func()
+    }
+
+    fun WithANoNetworkError(func: () -> Unit) {
+        `when`(repository.getFact())
+            .thenReturn(Observable.error(NetworkIssues.NoNetwork))
+        func()
+    }
+
+    fun WithATimeoutError(func: () -> Unit) {
+        `when`(repository.getFact())
+            .thenReturn(Observable.error(NetworkIssues.Timeout))
+        func()
+    }
+
+    fun WithAFactNotFoundError(func: () -> Unit) {
+        `when`(repository.getFact())
+            .thenReturn(Observable.error(IntegrationErrors.FactNotFound))
+        func()
+    }
+
+    fun WithAUnavailableProviderError(func: () -> Unit) {
+        `when`(repository.getFact())
+            .thenReturn(Observable.error(IntegrationErrors.UnavailableProvider))
+        func()
+    }
+
+    fun WithAUnexpectedDataError(func: () -> Unit) {
+        `when`(repository.getFact())
+            .thenReturn(Observable.error(IntegrationErrors.UnexpectedData))
+        func()
+    }
+}

--- a/domain/src/test/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactMother.kt
+++ b/domain/src/test/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactMother.kt
@@ -1,52 +1,53 @@
 package br.stone.mobiletraining.samilasantos.domain.randomFact
 
 import br.stone.mobiletraining.samilasantos.domain.common.Fact
-import br.stone.mobiletraining.samilasantos.domain.common.IntegrationErrors
+import br.stone.mobiletraining.samilasantos.domain.common.IntegrationExceptions
 import br.stone.mobiletraining.samilasantos.domain.common.NetworkIssues
-import io.reactivex.Observable
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
+import br.stone.mobiletraining.samilasantos.domain.randomFact.uc.RandomFactExceptions
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import io.reactivex.Single
 
 object RandomFactMother {
-    val repository: RandomFactRepository = mock(RandomFactRepository::class.java)
+    val repository: RandomFactRepository = mock()
 
     fun withASuccessScenario(func: () -> Unit) {
-        `when`(repository.getFact())
+        whenever(repository.getFact())
             .thenReturn(
-                Observable.just(Fact(id = "AFEG7878DD",
+                Single.just(Fact(id = "AFEG7878DD",
                     description = "Chuck Norris is Extreme Go Horse Father",
                     url = "")
                 ))
         func()
     }
 
-    fun WithANoNetworkError(func: () -> Unit) {
-        `when`(repository.getFact())
-            .thenReturn(Observable.error(NetworkIssues.NoNetwork))
+    fun withANoNetworkError(func: () -> Unit) {
+        whenever(repository.getFact())
+            .thenReturn(Single.error(NetworkIssues.NoNetwork))
         func()
     }
 
-    fun WithATimeoutError(func: () -> Unit) {
-        `when`(repository.getFact())
-            .thenReturn(Observable.error(NetworkIssues.Timeout))
+    fun withATimeoutError(func: () -> Unit) {
+        whenever(repository.getFact())
+            .thenReturn(Single.error(NetworkIssues.Timeout))
         func()
     }
 
-    fun WithAFactNotFoundError(func: () -> Unit) {
-        `when`(repository.getFact())
-            .thenReturn(Observable.error(IntegrationErrors.FactNotFound))
+    fun withAFactNotFoundError(func: () -> Unit) {
+        whenever(repository.getFact())
+            .thenReturn(Single.error(RandomFactExceptions.FactNotFound))
         func()
     }
 
-    fun WithAUnavailableProviderError(func: () -> Unit) {
-        `when`(repository.getFact())
-            .thenReturn(Observable.error(IntegrationErrors.UnavailableProvider))
+    fun withAUnavailableProviderError(func: () -> Unit) {
+        whenever(repository.getFact())
+            .thenReturn(Single.error(IntegrationExceptions.UnavailableProvider))
         func()
     }
 
-    fun WithAUnexpectedDataError(func: () -> Unit) {
-        `when`(repository.getFact())
-            .thenReturn(Observable.error(IntegrationErrors.UnexpectedData))
+    fun withAUnexpectedDataError(func: () -> Unit) {
+        whenever(repository.getFact())
+            .thenReturn(Single.error(IntegrationExceptions.UnexpectedData))
         func()
     }
 }

--- a/domain/src/test/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactTest.kt
+++ b/domain/src/test/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactTest.kt
@@ -1,0 +1,75 @@
+package br.stone.mobiletraining.samilasantos.domain.randomFact
+
+import br.stone.mobiletraining.samilasantos.domain.common.IntegrationErrors
+import br.stone.mobiletraining.samilasantos.domain.common.NetworkIssues
+import br.stone.mobiletraining.samilasantos.domain.randomFact.RandomFactMother.repository
+import br.stone.mobiletraining.samilasantos.domain.randomFact.uc.GetRandomFact
+import org.junit.Test
+
+class RandomFactTest {
+
+    @Test
+    fun shouldReturnANoNetworkError() {
+        RandomFactMother.WithANoNetworkError {
+            val ts = GetRandomFact(repository)
+                .execute().test()
+            ts.awaitTerminalEvent()
+            ts.assertValue { it is RandomFactResult.Error }
+            ts.assertValue { (it as RandomFactResult.Error).error == NetworkIssues.NoNetwork }
+        }
+    }
+
+    @Test
+    fun shouldReturnATimeoutError() {
+        RandomFactMother.WithATimeoutError {
+            val ts = GetRandomFact(repository)
+                .execute().test()
+            ts.awaitTerminalEvent()
+            ts.assertValue { it is RandomFactResult.Error }
+            ts.assertValue { (it as RandomFactResult.Error).error == NetworkIssues.Timeout }
+        }
+    }
+
+    @Test
+    fun shouldReturnAFactNotFoundError() {
+        RandomFactMother.WithAFactNotFoundError {
+            val ts = GetRandomFact(repository)
+                .execute().test()
+            ts.awaitTerminalEvent()
+            ts.assertValue { it is RandomFactResult.Error }
+            ts.assertValue { (it as RandomFactResult.Error).error == IntegrationErrors.FactNotFound }
+        }
+    }
+
+    @Test
+    fun shouldReturnAUnexpectedDataError() {
+        RandomFactMother.WithAUnexpectedDataError {
+            val ts = GetRandomFact(repository)
+                .execute().test()
+            ts.awaitTerminalEvent()
+            ts.assertValue { it is RandomFactResult.Error }
+            ts.assertValue { (it as RandomFactResult.Error).error == IntegrationErrors.UnexpectedData }
+        }
+    }
+
+    @Test
+    fun shouldReturnAUnavailableProviderError() {
+        RandomFactMother.WithAUnavailableProviderError {
+            val ts = GetRandomFact(repository)
+                .execute().test()
+            ts.awaitTerminalEvent()
+            ts.assertValue { it is RandomFactResult.Error }
+            ts.assertValue { (it as RandomFactResult.Error).error == IntegrationErrors.UnavailableProvider }
+        }
+    }
+
+    @Test
+    fun shouldReturnSuccess() {
+        RandomFactMother.withASuccessScenario {
+            val ts = GetRandomFact(repository)
+                .execute().test()
+            ts.awaitTerminalEvent()
+            ts.assertValue { it is RandomFactResult.Success }
+        }
+    }
+}

--- a/domain/src/test/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactTest.kt
+++ b/domain/src/test/java/br/stone/mobiletraining/samilasantos/domain/randomFact/RandomFactTest.kt
@@ -1,16 +1,17 @@
 package br.stone.mobiletraining.samilasantos.domain.randomFact
 
-import br.stone.mobiletraining.samilasantos.domain.common.IntegrationErrors
+import br.stone.mobiletraining.samilasantos.domain.common.IntegrationExceptions
 import br.stone.mobiletraining.samilasantos.domain.common.NetworkIssues
 import br.stone.mobiletraining.samilasantos.domain.randomFact.RandomFactMother.repository
 import br.stone.mobiletraining.samilasantos.domain.randomFact.uc.GetRandomFact
+import br.stone.mobiletraining.samilasantos.domain.randomFact.uc.RandomFactExceptions
 import org.junit.Test
 
 class RandomFactTest {
 
     @Test
-    fun shouldReturnANoNetworkError() {
-        RandomFactMother.WithANoNetworkError {
+    fun `given a no network error, GetRandomFact should return an error`() {
+        RandomFactMother.withANoNetworkError {
             val ts = GetRandomFact(repository)
                 .execute().test()
             ts.awaitTerminalEvent()
@@ -20,8 +21,8 @@ class RandomFactTest {
     }
 
     @Test
-    fun shouldReturnATimeoutError() {
-        RandomFactMother.WithATimeoutError {
+    fun `given a timeout error, GetRandomFact should return an error`() {
+        RandomFactMother.withATimeoutError {
             val ts = GetRandomFact(repository)
                 .execute().test()
             ts.awaitTerminalEvent()
@@ -31,40 +32,40 @@ class RandomFactTest {
     }
 
     @Test
-    fun shouldReturnAFactNotFoundError() {
-        RandomFactMother.WithAFactNotFoundError {
+    fun `given a fact not found error, GetRandomFact should return an error`() {
+        RandomFactMother.withAFactNotFoundError {
             val ts = GetRandomFact(repository)
                 .execute().test()
             ts.awaitTerminalEvent()
             ts.assertValue { it is RandomFactResult.Error }
-            ts.assertValue { (it as RandomFactResult.Error).error == IntegrationErrors.FactNotFound }
+            ts.assertValue { (it as RandomFactResult.Error).error == RandomFactExceptions.FactNotFound }
         }
     }
 
     @Test
-    fun shouldReturnAUnexpectedDataError() {
-        RandomFactMother.WithAUnexpectedDataError {
+    fun `given an unexpected data error, GetRandomFact should return an error`() {
+        RandomFactMother.withAUnexpectedDataError {
             val ts = GetRandomFact(repository)
                 .execute().test()
             ts.awaitTerminalEvent()
             ts.assertValue { it is RandomFactResult.Error }
-            ts.assertValue { (it as RandomFactResult.Error).error == IntegrationErrors.UnexpectedData }
+            ts.assertValue { (it as RandomFactResult.Error).error == IntegrationExceptions.UnexpectedData }
         }
     }
 
     @Test
-    fun shouldReturnAUnavailableProviderError() {
-        RandomFactMother.WithAUnavailableProviderError {
+    fun `given a unavailable provider error, GetRandomFact should return an error`() {
+        RandomFactMother.withAUnavailableProviderError {
             val ts = GetRandomFact(repository)
                 .execute().test()
             ts.awaitTerminalEvent()
             ts.assertValue { it is RandomFactResult.Error }
-            ts.assertValue { (it as RandomFactResult.Error).error == IntegrationErrors.UnavailableProvider }
+            ts.assertValue { (it as RandomFactResult.Error).error == IntegrationExceptions.UnavailableProvider }
         }
     }
 
     @Test
-    fun shouldReturnSuccess() {
+    fun `given success scenario, GetRandomFact should return success`() {
         RandomFactMother.withASuccessScenario {
             val ts = GetRandomFact(repository)
                 .execute().test()


### PR DESCRIPTION
### :pushpin: Referências

* **Repositório da Atividade:** [Ex03](https://github.com/stone-payments/mobile-training/blob/master/ex03-chucknorris.md) 

### :cyclone: Mudanças

Este PR adiciona a camada de domínio da feature que contempla a recuperação de um fato randômico do serviço e define contratos de comunicação com esta camada.
 
### :art: Mudanças de UI
_Não foram adicionadas mudanças de ui_

### :memo: Notas

NA